### PR TITLE
Update for macOS 12 Monterey

### DIFF
--- a/supported_os_data.yml
+++ b/supported_os_data.yml
@@ -1,4 +1,4 @@
-current_os: 11.4
+current_os: 12.0
 shipping:
   Xserve:
     '11': 10.4.8
@@ -109,20 +109,23 @@ highest:
     '31': 10.11.6
     '61': 10.13.6
     '91': 10.15.7
-    '111': '0'
+    '111': 11.4
+    '114': '0'
   MacBookAir:
     '11': 10.7.5
     '21': 10.11.6
     '31': 10.13.6
     '51': 10.15.7
-    '61': '0'
+    '61': 11.4
+    '71': '0'
   iMac:
     '41': 10.6.8
     '51': 10.7.5
     '71': 10.11.6
     '101': 10.13.6
     '131': 10.15.7
-    '144': '0'
+    '151': 11.4
+    '161': '0'
   iMacPro:
     '11': '0'
   MacBook:
@@ -130,5 +133,6 @@ highest:
     '21': 10.7.5
     '51': 10.11.6
     '61': 10.13.6
-    '81': '0'
+    '81': 11.4
+    '91': '0'
 ReadMe: YAML file used by MunkiReports supported_os module to determine current OS, maximum supported, and shipping OS versions


### PR DESCRIPTION
Updates for models that will support macOS 12 Monterey.

I can't remember how we handled this last summer, but it will be nice to get a head start on seeing which devices will need to be replaced because they are have reached the end of the road with Big Sur.